### PR TITLE
fix: manifest fs mount path for `libdcap_quoteprov.so`

### DIFF
--- a/era-fee-withdrawer.manifest.toml
+++ b/era-fee-withdrawer.manifest.toml
@@ -35,7 +35,7 @@ root.uri = "file:/"
 start_dir = "/app"
 mounts = [
   { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
-  { path = "file:{{ gramine.runtimedir() }}/libdcap_quoteprov.so", uri = "file:/lib/libdcap_quoteprov.so" },
+  { path = "{{ gramine.runtimedir() }}/libdcap_quoteprov.so", uri = "file:/lib/libdcap_quoteprov.so" },
   { type = "tmpfs", path = "/var/tmp" },
   { type = "tmpfs", path = "/tmp" },
   { type = "tmpfs", path = "/app/.dcap-qcnl" },


### PR DESCRIPTION
fixes 737600e2337c44037eae4b74f123fd9dc1a0a947