### PR TITLE
fix: reduce sgx manifest `/etc/` to ssl bundle

### DIFF
--- a/Dockerfile-azure
+++ b/Dockerfile-azure
@@ -4,8 +4,10 @@ WORKDIR /app
 
 COPY enclave-key.pem era-fee-withdrawer.manifest.toml ./
 
+RUN printf "precedence ::ffff:0:0/96  100\n" > /etc/gai.conf
+
 # The final touch for a reproducible docker file
-RUN touch -r /nix/store * .?*
+RUN touch -r /nix/store * .?* /etc/gai.conf
 
 RUN set -eux; export HOME=/app; \
     gramine-manifest -Darch_libdir=/lib -Dexecdir=/bin -Dlog_level=error era-fee-withdrawer.manifest.toml era-fee-withdrawer.manifest; \
@@ -21,5 +23,5 @@ ENTRYPOINT ["/bin/sh", "-c"]
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
 ENV UV_USE_IO_URING=0
 
-# CMD [ "echo tee-era-fee-withdrawer in simulation mode starting ; exec gramine-direct era-fee-withdrawer" ]
+#CMD [ "echo tee-era-fee-withdrawer in simulation mode starting ; exec gramine-direct era-fee-withdrawer" ]
 CMD [ "echo tee-era-fee-withdrawer in SGX mode starting ; restart-aesmd ; exec gramine-sgx era-fee-withdrawer" ]

--- a/Dockerfile-dcap
+++ b/Dockerfile-dcap
@@ -7,8 +7,10 @@ RUN rm /etc/sgx_default_qcnl.conf && ln -s /app/sgx_default_qcnl.conf /etc/sgx_d
 
 COPY enclave-key.pem era-fee-withdrawer.manifest.toml ./
 
+RUN printf "precedence ::ffff:0:0/96  100\n" > /etc/gai.conf
+
 # The final touch for a reproducible docker file
-RUN touch -r /nix/store * .?*
+RUN touch -r /nix/store * .?* /etc/gai.conf
 
 RUN set -eux; export HOME=/app; \
     gramine-manifest -Darch_libdir=/lib -Dexecdir=/bin -Dlog_level=error era-fee-withdrawer.manifest.toml era-fee-withdrawer.manifest; \
@@ -21,5 +23,8 @@ RUN set -eux; export HOME=/app; \
 RUN touch -r /nix/store era-fee-withdrawer.sig
 
 ENTRYPOINT ["/bin/sh", "-c"]
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+ENV UV_USE_IO_URING=0
+
 #CMD [ "echo era-fee-withdrawer in simulation mode starting ; exec gramine-direct era-fee-withdrawer" ]
 CMD [ "echo era-fee-withdrawer in SGX mode starting ; restart-aesmd ; exec gramine-sgx era-fee-withdrawer" ]

--- a/era-fee-withdrawer.manifest.toml
+++ b/era-fee-withdrawer.manifest.toml
@@ -56,8 +56,7 @@ trusted_files = [
   "file:/lib/",
   "file:/nix/",
   "file:/app/",
-  "file:/etc/",
-  "file:/etc/ssl/",
+  "file:/etc/ssl/certs/ca-bundle.crt",
 ]
 
 [sys]

--- a/era-fee-withdrawer.manifest.toml
+++ b/era-fee-withdrawer.manifest.toml
@@ -57,12 +57,10 @@ trusted_files = [
   "file:/nix/",
   "file:/app/",
   "file:/etc/ssl/certs/ca-bundle.crt",
+  "file:/etc/gai.conf",
 ]
 
 [sys]
 stack.size = "1M"
 enable_extra_runtime_domain_names_conf = true
 enable_sigterm_injection = true
-
-experimental__enable_flock = true
-insecure__allow_eventfd = true

--- a/flake.lock
+++ b/flake.lock
@@ -128,11 +128,11 @@
         "snowfall-lib": "snowfall-lib"
       },
       "locked": {
-        "lastModified": 1706650888,
-        "narHash": "sha256-DAUAkNvHGC/w1sO7KpDMYTBCXKeI/pep0uY8bE9EHCU=",
+        "lastModified": 1706717028,
+        "narHash": "sha256-paQ5fBXWRpYdQMXphi8/gahl3/ptej4kncqxsMFguH4=",
         "owner": "haraldh",
         "repo": "nixsgx",
-        "rev": "b086eab2aba759be2ef87c91781174f7f021aead",
+        "rev": "ff39bbbbbf7e88a28eeace784784839f1bf7e3b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
because otherwise all podman/docker injected/modified files would be measured in the final build phase.